### PR TITLE
Add an overlap so requests don't get missed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,11 @@ docker run -e "STRIPE_KEY=..." -e "WEBHOOK_URL=..." jsonmaur/stripe-local
   > Type: number  
   > Default: `5000` (5s)
 
+- `overlap` The amount of time (in milliseconds) to overlap with the last request. Because multiple stripe events can happen per second if there is no overlap some events may be missed.
+  
+  > Type: number
+  > Default: `2000` (2s)
+
 - `quiet` Whether to hide all logged messages.
 
   > Type: boolean  

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ module.exports = (opts = {}) => {
     }
   })
 
-  let processedEvents = [];
+  let processedEvents = []
 
   let lastTimestamp = currentTimeStamp() - (opts.interval / 1000)
   setInterval(() => {
@@ -42,10 +42,11 @@ module.exports = (opts = {}) => {
 
       lastTimestamp = currentTimeStamp()
       const eventsToProcess = evts.data.filter(evt => !processedEvents.includes(evt.id))
-      if(eventsToProcess.length)
+      if (eventsToProcess.length) {
         processedEvents.splice(0, processedEvents.length, [...eventsToProcess.map(evt => evt.id)])
-      
-        Promise.all(eventsToProcess.map(evt => {
+      }
+
+      Promise.all(eventsToProcess.map(evt => {
         return stripe.events.retrieve(evt.id)
           .then(data => {
             !opts.quiet && console.log(`Received Stripe Event: ${evt.id}`)

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ module.exports = (opts = {}) => {
   opts.interval = opts.interval
     ? parseInt(opts.interval, 10)
     : 5000
+  opts.overlap = opts.overlap ? parseInt(opts.overlap, 10) : 2000
 
   const stripe = Stripe(opts.secretKey)
   const currentTimeStamp = () => Math.floor(Date.now() / 1000)
@@ -28,17 +29,23 @@ module.exports = (opts = {}) => {
     }
   })
 
+  let processedEvents = [];
+
   let lastTimestamp = currentTimeStamp() - (opts.interval / 1000)
   setInterval(() => {
     stripe.events.list({
       created: {
-        gt: lastTimestamp
+        gt: lastTimestamp - (opts.overlap / 1000)
       }
     }, (err, evts) => {
       if (err) return console.error(err)
 
       lastTimestamp = currentTimeStamp()
-      Promise.all(evts.data.map(evt => {
+      const eventsToProcess = evts.data.filter(evt => !processedEvents.includes(evt.id))
+      if(eventsToProcess.length)
+        processedEvents.splice(0, processedEvents.length, [...eventsToProcess.map(evt => evt.id)])
+      
+        Promise.all(eventsToProcess.map(evt => {
         return stripe.events.retrieve(evt.id)
           .then(data => {
             !opts.quiet && console.log(`Received Stripe Event: ${evt.id}`)


### PR DESCRIPTION
In stripe many events can happen in the same second. This can cause some events to get missed if there's no overlap in the request times.

This PR adds an overlap of a default  2 seconds to make sure all the events get pulled down. To keep from having multiple requests processed I added a local array of event ids to filter the new request. This ensures events don't get processed twice in case the consumer doesn't have any protection against that. After the new events are filtered the array is overwritten with the new event ids for future request.