### PR TITLE
Add stripe webhook secret for Docker

### DIFF
--- a/docker/index.js
+++ b/docker/index.js
@@ -1,4 +1,5 @@
 require('stripe-local')({
   secretKey: process.env.STRIPE_KEY,
+  webhookSecret: process.env.STRIPE_SIGNING_SECRET,
   webhookUrl: process.env.WEBHOOK_URL
 })


### PR DESCRIPTION
Thanks for building this!

This pull request adds the ability to easily add a signing key to the Docker setup. I added it because I wanted to test signing at different levels in the app I'm working on and having this here was a big help. 